### PR TITLE
Add GitHub workflow to build & deploy images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+# Build Apptainer images and push them to the GitHub Container Registry of the
+# repository.
+#
+# Runs automatically on pushes to master if they modify a def file and can also
+# be executed manually ("workflow_dispatch" event).
+# Images from the master branch are pushed with the "latest" tag, others with
+# the name of the branch.
+#
+name: Apptainer Build & Deploy
+on: 
+  push:
+    branches:
+      - master
+    paths:
+      - "*.def"
+  workflow_dispatch:
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Install Apptainer
+              run: |
+                wget https://github.com/apptainer/apptainer/releases/download/v1.0.2/apptainer_1.0.2_amd64.deb
+                sudo apt-get install ./apptainer_1.0.2_amd64.deb
+
+            - name: Check out code for the container build
+              uses: actions/checkout@v2
+
+            - name: Install treep
+              run: |
+                python3 -m pip install treep
+
+            - name: Build pam_base.sif
+              run: make pam_base.sif USE_SUDO=1
+
+            - name: Build pam_mujoco.sif
+              run: make pam_mujoco.sif USE_SUDO=1
+
+            - name: Login and Deploy Container
+              run: |
+                if [ "${GITHUB_REF_NAME}" = "master" ]
+                then
+                  tag=latest
+                else
+                  tag=${GITHUB_REF_NAME}
+                fi
+
+                echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
+
+                singularity push pam_base.sif oras://ghcr.io/${GITHUB_REPOSITORY}/pam_base:${tag}
+                singularity push pam_mujoco.sif oras://ghcr.io/${GITHUB_REPOSITORY}/pam_mujoco:${tag}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 sifs = pam_base.sif pam_mujoco.sif learning_table_tennis_from_scratch.sif
 
+USE_SUDO = 0
+
 .PHONY: all
 all: $(sifs)
 
@@ -30,4 +32,8 @@ learning_table_tennis_from_scratch.def: pam_mujoco.sif build/cluster_utils
 
 # build arbitrary def file
 %.sif: %.def
+ifeq ($(USE_SUDO),1)
+	sudo singularity build $@ $<
+else
 	singularity build --fakeroot $@ $<
+endif

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build/pam_mujoco_ws:
 	mkdir -p build/pam_mujoco_ws
 	cd build/pam_mujoco_ws; \
 		git clone https://github.com/intelligent-soft-robots/treep_isr.git; \
-		treep --clone PAM_MUJOCO;
+		treep --clone-https PAM_MUJOCO;
 
 build/cluster_utils:
 	mkdir -p build


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Add GitHub workflow that builds the "pam_base" and "pam_mujoco"
containers and pushes them to GHCR.
It is triggered automatically for pushes to master and can also be run
manually.

For this some changes in the Makefile are needed:
- Use `treep --clone-https` to get the packages (so no SSH key is needed)
- Add option to build with sudo (fakeroot was not working)

## How I Tested
Tested earlier via this pull request (using "pull_request" event).  The final version can unfortunately not be tested before it is merged to master.